### PR TITLE
Feature/notification fetch and schema update

### DIFF
--- a/backend/pkg/db/sqlite/000023_add_background_image_column.down.sql
+++ b/backend/pkg/db/sqlite/000023_add_background_image_column.down.sql
@@ -1,0 +1,1 @@
+ALTER TABLE users DROP COLUMN background_image;

--- a/backend/pkg/db/sqlite/000023_add_background_image_column.up.sql
+++ b/backend/pkg/db/sqlite/000023_add_background_image_column.up.sql
@@ -1,0 +1,1 @@
+ALTER TABLE users ADD COLUMN background_image TEXT;

--- a/backend/pkg/handler/notification.go
+++ b/backend/pkg/handler/notification.go
@@ -15,5 +15,5 @@ func (app *App) Notifications(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	
+	app.JSONResponse(w, r, http.StatusOK, notifications, Success)
 }

--- a/backend/pkg/handler/notification.go
+++ b/backend/pkg/handler/notification.go
@@ -8,4 +8,12 @@ func (app *App) Notifications(w http.ResponseWriter, r *http.Request) {
 		app.JSONResponse(w, r, http.StatusUnauthorized, "Unauthorized", Error)
 		return
 	}
+
+	notifications, err := app.Queries.GetUserNotifications(userID)
+	if err != nil {
+		app.JSONResponse(w, r, http.StatusConflict, "Error while fetching notifications")
+		return
+	}
+
+	
 }

--- a/backend/pkg/handler/notification.go
+++ b/backend/pkg/handler/notification.go
@@ -1,0 +1,5 @@
+package handler
+
+import "net/http"
+
+func (app *App) Notifications(w http.ResponseWriter, r *http.Request) {}

--- a/backend/pkg/handler/notification.go
+++ b/backend/pkg/handler/notification.go
@@ -11,7 +11,7 @@ func (app *App) Notifications(w http.ResponseWriter, r *http.Request) {
 
 	notifications, err := app.Queries.GetUserNotifications(userID)
 	if err != nil {
-		app.JSONResponse(w, r, http.StatusConflict, "Error while fetching notifications")
+		app.JSONResponse(w, r, http.StatusConflict, "Error while fetching notifications", Error)
 		return
 	}
 

--- a/backend/pkg/handler/notification.go
+++ b/backend/pkg/handler/notification.go
@@ -2,4 +2,10 @@ package handler
 
 import "net/http"
 
-func (app *App) Notifications(w http.ResponseWriter, r *http.Request) {}
+func (app *App) Notifications(w http.ResponseWriter, r *http.Request) {
+	userID, err := app.GetSessionData(r)
+	if err != nil {
+		app.JSONResponse(w, r, http.StatusUnauthorized, "Unauthorized", Error)
+		return
+	}
+}

--- a/backend/pkg/handler/routes_handler.go
+++ b/backend/pkg/handler/routes_handler.go
@@ -10,22 +10,23 @@ import (
 )
 
 var allowedRoutes = map[string][]string{
-	"/api/login":        {"POST", "OPTIONS"},
-	"/api/register":     {"POST", "OPTIONS"},
-	"/api/addPost":      {"POST", "OPTIONS"},
-	"/api/getPosts":     {"GET", "OPTIONS"},
-	"/api/profile":      {"GET", "OPTIONS"},
-	"/api/logout":       {"POST", "OPTIONS"},
-	"/api/addGroup":     {"POST", "OPTIONS"},
-	"/api/getGroupData": {"GET", "POST", "OPTIONS"},
-	"/pkg/db/media/":    {"GET", "OPTIONS"},
-	"/api/addEvent":     {"POST", "OPTIONS"},
-	"/api/updateUser":   {"PATCH", "OPTIONS"},
-	"/api/groups":       {"GET", "OPTIONS"},
-	"/api/deleteGroup":  {"DELETE", "OPTIONS"},
-	"/api/ws":           {"GET", "OPTIONS"},
-	"/api/rsvp":         {"POST", "OPTIONS"},
-	"/api/users":        {"GET", "OPTIONS"},
+	"/api/login":         {"POST", "OPTIONS"},
+	"/api/register":      {"POST", "OPTIONS"},
+	"/api/addPost":       {"POST", "OPTIONS"},
+	"/api/getPosts":      {"GET", "OPTIONS"},
+	"/api/profile":       {"GET", "OPTIONS"},
+	"/api/logout":        {"POST", "OPTIONS"},
+	"/api/addGroup":      {"POST", "OPTIONS"},
+	"/api/getGroupData":  {"GET", "POST", "OPTIONS"},
+	"/pkg/db/media/":     {"GET", "OPTIONS"},
+	"/api/addEvent":      {"POST", "OPTIONS"},
+	"/api/updateUser":    {"PATCH", "OPTIONS"},
+	"/api/groups":        {"GET", "OPTIONS"},
+	"/api/deleteGroup":   {"DELETE", "OPTIONS"},
+	"/api/ws":            {"GET", "OPTIONS"},
+	"/api/rsvp":          {"POST", "OPTIONS"},
+	"/api/users":         {"GET", "OPTIONS"},
+	"/api/notifications": {"GET", "OPTIONS"},
 }
 
 type App struct {
@@ -90,6 +91,7 @@ func (app *App) Routes() http.Handler {
 	mux.Handle("/api/ws", app.AuthMiddleware(http.HandlerFunc(app.HandleWebsocket)))
 	mux.Handle("/api/rsvp", app.AuthMiddleware(http.HandlerFunc(app.Rsvp)))
 	mux.Handle("/api/users", app.AuthMiddleware(http.HandlerFunc(app.GetAllUsers)))
+	mux.Handle("/api/notifications", app.AuthMiddleware(http.HandlerFunc(app.Notifications)))
 
 	return mux
 }

--- a/backend/pkg/model/user.go
+++ b/backend/pkg/model/user.go
@@ -24,7 +24,7 @@ type UserNotification struct {
 	ID         string         `json:"id"`
 	ActorId    string         `json:"sender_id"`
 	Type       string         `json:"type"`
-	EntityID   sql.NullInt64  `json:"entity_id,omitempty"` 
+	EntityID   sql.NullInt64  `json:"entity_id,omitempty"`
 	EntityType sql.NullString `json:"entity_type,omitempty"`
 	IsRead     bool           `json:"is_read"`
 	Message    string         `json:"message"`

--- a/backend/pkg/model/user.go
+++ b/backend/pkg/model/user.go
@@ -1,6 +1,9 @@
 package model
 
-import "time"
+import (
+	"database/sql"
+	"time"
+)
 
 type User struct {
 	ID                string    `json:"id"`
@@ -18,22 +21,12 @@ type User struct {
 }
 
 type UserNotification struct {
-	ID         string    `json:"id"`
-	ActorId    string    `json:"sender_id"`
-	Type       string    `json:"type"`
-	EntityID   string    `json:"entity_id,omitempty"`
-	EntityType string    `json:"entity_type,omitempty"`
-	IsRead     bool      `json:"is_read"`
-	Message    string    `json:"message"`
-	CreatedAt  time.Time `json:"created_at"`
+	ID         string         `json:"id"`
+	ActorId    string         `json:"sender_id"`
+	Type       string         `json:"type"`
+	EntityID   sql.NullInt64  `json:"entity_id,omitempty"` 
+	EntityType sql.NullString `json:"entity_type,omitempty"`
+	IsRead     bool           `json:"is_read"`
+	Message    string         `json:"message"`
+	CreatedAt  time.Time      `json:"created_at"`
 }
-
-// id TEXT PRIMARY KEY NOT NULL UNIQUE,
-//     recipient_id TEXT NOT NULL,
-//     actor_id TEXT,
-//     type TEXT NOT NULL,
-//     entity_id INTEGER,
-//     entity_type TEXT,
-//     is_read BOOLEAN DEFAULT 0,
-//     message TEXT,
-//     created_at DATETIME DEFAULT CURRENT_TIMESTAMP,

--- a/backend/pkg/model/user.go
+++ b/backend/pkg/model/user.go
@@ -16,3 +16,24 @@ type User struct {
 	IsPublic          bool      `json:"is_public"`
 	CreatedAt         time.Time `json:"created_at"`
 }
+
+type UserNotification struct {
+	ID         string    `json:"id"`
+	ActorId    string    `json:"sender_id"`
+	Type       string    `json:"type"`
+	EntityID   string    `json:"entity_id,omitempty"`
+	EntityType string    `json:"entity_type,omitempty"`
+	IsRead     bool      `json:"is_read"`
+	Message    string    `json:"message"`
+	CreatedAt  time.Time `json:"created_at"`
+}
+
+// id TEXT PRIMARY KEY NOT NULL UNIQUE,
+//     recipient_id TEXT NOT NULL,
+//     actor_id TEXT,
+//     type TEXT NOT NULL,
+//     entity_id INTEGER,
+//     entity_type TEXT,
+//     is_read BOOLEAN DEFAULT 0,
+//     message TEXT,
+//     created_at DATETIME DEFAULT CURRENT_TIMESTAMP,

--- a/backend/pkg/model/userData.go
+++ b/backend/pkg/model/userData.go
@@ -3,22 +3,23 @@ package model
 import "time"
 
 type UserData struct {
-	ID            string     `json:"id"`
-	FirstName     string     `json:"first_name"`
-	LastName      string     `json:"last_name"`
-	Email         string     `json:"email"`
-	DateOfBirth   time.Time  `json:"date_of_birth"`
-	Avatar        string     `json:"avatar"`
-	Nickname      string     `json:"nickname"`
-	AboutMe       string     `json:"about_me"`
-	IsPublic      bool       `json:"is_public"`
-	CreatedAt     time.Time  `json:"created_at"`
-	Post          []Post     `json:"userposts"`
-	Comments      []Post     `json:"commentedpost"`
-	LikedPost     []Post     `json:"likedpost"`
-	LikedComments []Post     `json:"likedcomments"`
-	Followers     []Follower `json:"followers"`
-	Following     []Follower `json:"following"`
+	ID              string     `json:"id"`
+	FirstName       string     `json:"first_name"`
+	LastName        string     `json:"last_name"`
+	Email           string     `json:"email"`
+	DateOfBirth     time.Time  `json:"date_of_birth"`
+	Avatar          string     `json:"avatar"`
+	Nickname        string     `json:"nickname"`
+	AboutMe         string     `json:"about_me"`
+	IsPublic        bool       `json:"is_public"`
+	BackgroundImage string     `json:"background_image"`
+	CreatedAt       time.Time  `json:"created_at"`
+	Post            []Post     `json:"userposts"`
+	Comments        []Post     `json:"commentedpost"`
+	LikedPost       []Post     `json:"likedpost"`
+	LikedComments   []Post     `json:"likedcomments"`
+	Followers       []Follower `json:"followers"`
+	Following       []Follower `json:"following"`
 }
 
 type Follower struct {

--- a/backend/pkg/repository/fetchUserData.go
+++ b/backend/pkg/repository/fetchUserData.go
@@ -105,13 +105,13 @@ func (q *Query) FetchUserInfo(userid string, user *model.UserData) error {
 	row := q.Db.QueryRow(`
         SELECT email, first_name, last_name, 
 		date_of_birth, avatar, nickname , about_me, created_at , 
-		is_public 
+		is_public ,	background_image 
         FROM users 
         WHERE id = ? 
         LIMIT 1
     `, userid)
 
-	err := row.Scan(&user.Email, &user.FirstName, &user.LastName, &user.DateOfBirth, &user.Avatar, &user.Nickname, &user.AboutMe, &user.CreatedAt, &user.IsPublic)
+	err := row.Scan(&user.Email, &user.FirstName, &user.LastName, &user.DateOfBirth, &user.Avatar, &user.Nickname, &user.AboutMe, &user.CreatedAt, &user.IsPublic, &user.BackgroundImage)
 	if err == sql.ErrNoRows {
 		return errors.New("no user data found")
 	}

--- a/backend/pkg/repository/fetchUserNotifications.go
+++ b/backend/pkg/repository/fetchUserNotifications.go
@@ -47,12 +47,3 @@ func (q *Query) GetUserNotifications(userID string) ([]model.UserNotification, e
 
 }
 
-// id TEXT PRIMARY KEY NOT NULL UNIQUE,
-//     recipient_id TEXT NOT NULL, 
-//     actor_id TEXT,              
-//     type TEXT NOT NULL,            
-//     entity_id INTEGER,             
-//     entity_type TEXT,              
-//     is_read BOOLEAN DEFAULT 0,     
-//     message TEXT,                 
-//     created_at DATETIME DEFAULT CURRENT_TIMESTAMP,

--- a/backend/pkg/repository/fetchUserNotifications.go
+++ b/backend/pkg/repository/fetchUserNotifications.go
@@ -1,0 +1,58 @@
+package repository
+
+import (
+	"social/pkg/model"
+	"fmt"
+)
+
+func (q *Query) GetUserNotifications(userID string) ([]model.UserNotification, error) {
+	query := `
+		SELECT
+			un.id,
+			un.actor_id,
+			un.type,
+			un.entity_id,
+			un.entity_type,
+			un.is_read,
+			un.message,
+			un.created_at
+		FROM notifications un
+		WHERE recipient_id = ?
+	`
+
+	rows, err := q.Db.Query(query, userID)
+	if err != nil {
+		return nil, fmt.Errorf("failed to user notifications : %w", err)
+	}
+
+	defer rows.Close()
+
+	var notifications []model.UserNotification
+
+	for rows.Next() {
+		var notification model.UserNotification
+
+		err := rows.Scan(
+			&notification.ID, &notification.ActorId, &notification.Type, &notification.EntityID, &notification.EntityType,
+			&notification.IsRead, &notification.Message, &notification.CreatedAt,
+		)
+		if err != nil {
+			return nil, fmt.Errorf("failed to scan notification: %w", err)
+		}
+
+		notifications = append(notifications, notification)
+
+	}
+	return notifications, nil
+
+}
+
+// id TEXT PRIMARY KEY NOT NULL UNIQUE,
+//     recipient_id TEXT NOT NULL, 
+//     actor_id TEXT,              
+//     type TEXT NOT NULL,            
+//     entity_id INTEGER,             
+//     entity_type TEXT,              
+//     is_read BOOLEAN DEFAULT 0,     
+//     message TEXT,                 
+//     created_at DATETIME DEFAULT CURRENT_TIMESTAMP,


### PR DESCRIPTION
## Summary

This PR introduces a new API endpoint to fetch user notifications. It consists of:

* A database query function to retrieve user-specific notifications.
* An HTTP handler that authenticates the user and returns the notification list as a JSON response.

## Changes Made

### `repository/fetchuserNotifications.go`

#### Function: `GetUserNotifications(userID string)`

Fetches all notifications for a given user (`recipient_id`) from the `notifications` table.

* Fields returned:

  * `id`
  * `actor_id` (as `sender_id` in the response)
  * `type`
  * `entity_id`
  * `entity_type`
  * `is_read`
  * `message`
  * `created_at`

### `handler/notifications.go`

#### Function: `Notifications(w http.ResponseWriter, r *http.Request)`

* Verifies the user's session.
* Calls `GetUserNotifications(userID)` to retrieve notifications.
* Sends the result as a JSON response with a structure like:

```json
{
  "message": [
    {
      "id": "525b039e-a95d-4b53-93be-8edbeaa52a42",
      "sender_id": "557afccc-5401-400e-80cd-0d30054fbbcc",
      "type": "follow_request",
      "entity_id": {
        "Int64": 0,
        "Valid": false
      },
      "entity_type": {
        "String": "",
        "Valid": false
      },
      "is_read": false,
      "message": "new follow request",
      "created_at": "2025-06-15T15:23:26Z"
    },
    ...
  ]
}
```

## Behavior

* Returns `401 Unauthorized` if the session is invalid or missing.
* Returns `409 Conflict` if the database query fails.
* Returns `200 OK` with a list of notifications otherwise.

##  Checklist

* [x] Database query for fetching user-specific notifications.
* [x] HTTP handler with proper session validation.
* [x] Returns structured JSON response.
* [x] Errors and empty states are handled gracefully.

## How to Test

1. Log in or simulate a session via Postman or frontend.
2. Send a `GET` request to `/api/notifications`.
3. Expect a JSON response containing the user's notifications.

Closes #56 
Closes #57