### PR TITLE
Feature/group event notifications websocket

### DIFF
--- a/backend/pkg/db/sqlite/000024_add_grouprecepient_to_notification.down.sql
+++ b/backend/pkg/db/sqlite/000024_add_grouprecepient_to_notification.down.sql
@@ -1,0 +1,1 @@
+ALTER TABLE notifications DROP COLUMN recipient_group_id TEXT;

--- a/backend/pkg/db/sqlite/000024_add_grouprecepient_to_notification.up.sql
+++ b/backend/pkg/db/sqlite/000024_add_grouprecepient_to_notification.up.sql
@@ -1,0 +1,1 @@
+ALTER TABLE notifications ADD COLUMN recipient_group_id TEXT;

--- a/backend/pkg/model/user.go
+++ b/backend/pkg/model/user.go
@@ -23,6 +23,7 @@ type User struct {
 type UserNotification struct {
 	ID         string         `json:"id"`
 	Actor      *User          `json:"actor,omitempty"`
+	GroupID    sql.NullString `json:"group_id"`
 	Type       string         `json:"type"`
 	EntityID   sql.NullString `json:"entity_id,omitempty"`
 	EntityType sql.NullString `json:"entity_type,omitempty"`

--- a/backend/pkg/model/websocketModels.go
+++ b/backend/pkg/model/websocketModels.go
@@ -37,3 +37,11 @@ type GroupMessage struct {
 type Notification struct {
 	NotificationId string `json:"notification_id"`
 }
+
+type AddEventData struct {
+	Title       string    `json:"title"`
+	Description string    `json:"description"`
+	EventTime   time.Time `json:"event_time"`
+	GroupTitle  string    `json:"group_title"`
+	Location    string    `json:"location"`
+}

--- a/backend/pkg/repository/fetchAllUsers.go
+++ b/backend/pkg/repository/fetchAllUsers.go
@@ -72,7 +72,7 @@ func (q *Query) FetchNonMutual(userID string) ([]model.Follower, error) {
 		ORDER BY u.created_at ASC
         LIMIT 100
 	`
-	rows, err := q.Db.Query(query, userID, userID, userID)
+	rows, err := q.Db.Query(query, userID, userID, userID, userID)
 	if err != nil {
 		log.Printf("FetchAllUsers: db error: %v", err)
 		return nil, fmt.Errorf("failed to fetch non mutuL users: %w", err)

--- a/backend/pkg/repository/fetchAllUsers.go
+++ b/backend/pkg/repository/fetchAllUsers.go
@@ -56,17 +56,18 @@ func (q *Query) FetchAllUsers(userID string) (model.AllUsers, error) {
 func (q *Query) FetchNonMutual(userID string) ([]model.Follower, error) {
 	var users []model.Follower
 	query := `
-		SELECT 
-			u.id, u.first_name, u.last_name, u.avatar,  
+		SELECT
+			u.id, u.first_name, u.last_name, u.avatar,
 			u.is_public
 		FROM users u
-		WHERE u.id != ? 
+		WHERE u.id != ?
 		AND NOT EXISTS (
       		SELECT 1
      			FROM user_follows uf
-      			WHERE 
+      			WHERE
         		(uf.follower_id = u.id AND uf.following_id = ?) OR
-        		(uf.follower_id = ? AND uf.following_id = u.id)
+        		(uf.follower_id = ? AND uf.following_id = u.id) OR
+          		(uf.follower_id = u.id AND uf.following_id = ? AND uf.status = 'declined')
  		)
 		ORDER BY u.created_at ASC
         LIMIT 100
@@ -101,7 +102,7 @@ func (q *Query) FetchNonMutual(userID string) ([]model.Follower, error) {
 // with a 'pending' status. These are the users the given user wants to follow.
 func (q *Query) FetchSentFollowRequests(userID string) ([]model.Follower, error) {
 	query := `
-        SELECT 
+        SELECT
             u.id,
             u.first_name,
             u.last_name,
@@ -137,7 +138,7 @@ func (q *Query) FetchSentFollowRequests(userID string) ([]model.Follower, error)
 // to the given user. These are users who want to follow the given user and are waiting for approval.
 func (q *Query) FetchReceivedFollowRequests(userID string) ([]model.Follower, error) {
 	query := `
-        SELECT 
+        SELECT
             u.id,
             u.first_name,
             u.last_name,
@@ -171,11 +172,11 @@ func (q *Query) FetchReceivedFollowRequests(userID string) ([]model.Follower, er
 
 func (q *Query) GetFollowersNotFollowedBack(userID string) ([]model.Follower, error) {
 	query := `
-        SELECT 
+        SELECT
             u.id, u.first_name, u.last_name, u.avatar, u.is_public
         FROM user_follows uf
         JOIN users u ON uf.follower_id = u.id
-        WHERE uf.following_id = ? 
+        WHERE uf.following_id = ?
         AND uf.status = 'accepted'
         AND NOT EXISTS (
           SELECT 1
@@ -183,7 +184,7 @@ func (q *Query) GetFollowersNotFollowedBack(userID string) ([]model.Follower, er
           WHERE uf2.follower_id = ?
             AND uf2.following_id = uf.follower_id
             AND uf2.status = 'accepted'
-        ) 
+        )
 		ORDER BY uf.created_at ASC
         LIMIT 100
     `

--- a/backend/pkg/repository/getGroups.go
+++ b/backend/pkg/repository/getGroups.go
@@ -26,3 +26,26 @@ func (q *Query) GetUserGroupIDs(userID string) ([]string, error) {
 
 	return groupIDs, nil
 }
+
+func (q *Query) FetchAllGroupMembersId(groupID string) ([]string, error) {
+	rows, err := q.Db.Query(`
+		SELECT user_id
+		FROM group_members
+		WHERE group_id = ?`, groupID)
+
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	var userID []string
+	for rows.Next() {
+		var user string
+		if err := rows.Scan(&user); err != nil {
+			return nil, err
+		}
+		userID = append(userID, user)
+	}
+
+	return userID, nil
+}

--- a/backend/pkg/websocket/eventNotification.go
+++ b/backend/pkg/websocket/eventNotification.go
@@ -1,0 +1,81 @@
+package websocket
+
+import (
+	"encoding/json"
+	"fmt"
+	"social/pkg/model"
+	"social/pkg/repository"
+	"social/pkg/util"
+)
+
+func (c *Client) SendEventNotification(msg map[string]any, q *repository.Query, h *Hub) {
+	data, err := json.Marshal(msg["data"])
+	if err != nil {
+		c.SendError("Invalid data encoding")
+		return
+	}
+
+	var event model.AddEventData
+
+	if err = json.Unmarshal(data, &event); err != nil {
+		c.SendError("Invalid messsage format")
+		return
+	}
+
+	groupId, err := q.FetchGroupId(event.GroupTitle)
+	if err != nil {
+		c.SendError("group not found")
+		return
+	}
+
+	if event.Title == "" || event.EventTime.IsZero() {
+		c.SendError("Missing event name or time data")
+		return
+	}
+
+	eventID := util.UUIDGen()
+
+	err = q.InsertData("events", []string{
+		"id",
+		"title",
+		"creator_id",
+		"group_id",
+		"event_time",
+		"location",
+		"description",
+	}, []any{
+		eventID,
+		event.Title,
+		c.UserID,
+		groupId,
+		event.EventTime,
+		event.Location,
+		event.Description,
+	})
+	if err != nil {
+		c.SendError("failed to add event")
+		return
+	}
+
+	// add notification
+	eventStr := fmt.Sprintf(" created event - %s", event.Title)
+	err = q.InsertData("notifications", []string{
+		"id",
+		"actor_id",
+		"recipient_id",
+		"recipient_group_id",
+		"type",
+		"message",
+		"entity_id",
+		"entity_type",
+	}, []any{
+		util.UUIDGen(),
+		c.UserID,
+		"",
+		groupId,
+		"group_event",
+		eventStr,
+		eventID,
+		"group-event",
+	})
+}

--- a/backend/pkg/websocket/eventNotification.go
+++ b/backend/pkg/websocket/eventNotification.go
@@ -83,4 +83,23 @@ func (c *Client) SendEventNotification(msg map[string]any, q *repository.Query, 
 		c.SendError("failed to add notification")
 		return
 	}
+	payload := map[string]any{
+		"type": "notification",
+		"case": "group_event",
+		"data": map[string]any{
+			"title":       event.Title,
+			"event_time":  event.EventTime.Format("2006-01-02 15:04:05"),
+			"location":    event.Location,
+			"description": event.Description,
+		},
+	}
+
+	sendData, err := json.Marshal(payload)
+	if err != nil {
+		c.SendError("failed to marshal event data")
+		return
+	}
+
+	h.BroadcastToGroup(c, groupId, sendData)
+	c.SendSuccess("Event created successfully")
 }

--- a/backend/pkg/websocket/eventNotification.go
+++ b/backend/pkg/websocket/eventNotification.go
@@ -58,6 +58,12 @@ func (c *Client) SendEventNotification(msg map[string]any, q *repository.Query, 
 		return
 	}
 
+	memberIds, err := q.FetchAllGroupMembersId(groupId)
+	if err != nil {
+		c.SendError("failed to fetch group members")
+		return
+	}
+
 	// add notification
 	eventStr := fmt.Sprintf(" created event - %s", event.Title)
 	err = q.InsertData("notifications", []string{

--- a/backend/pkg/websocket/eventNotification.go
+++ b/backend/pkg/websocket/eventNotification.go
@@ -68,33 +68,34 @@ func (c *Client) SendEventNotification(msg map[string]any, q *repository.Query, 
 		if id == c.UserID {
 			continue
 		}
+
+		// add notification
+		eventStr := fmt.Sprintf(" created event - %s", event.Title)
+		err = q.InsertData("notifications", []string{
+			"id",
+			"actor_id",
+			"recipient_id",
+			"recipient_group_id",
+			"type",
+			"message",
+			"entity_id",
+			"entity_type",
+		}, []any{
+			util.UUIDGen(),
+			c.UserID,
+			id,
+			groupId,
+			"group_event",
+			eventStr,
+			eventID,
+			"group-event",
+		})
+		if err != nil {
+			c.SendError("failed to add notification")
+			return
+		}
 	}
 
-	// add notification
-	eventStr := fmt.Sprintf(" created event - %s", event.Title)
-	err = q.InsertData("notifications", []string{
-		"id",
-		"actor_id",
-		"recipient_id",
-		"recipient_group_id",
-		"type",
-		"message",
-		"entity_id",
-		"entity_type",
-	}, []any{
-		util.UUIDGen(),
-		c.UserID,
-		"",
-		groupId,
-		"group_event",
-		eventStr,
-		eventID,
-		"group-event",
-	})
-	if err != nil {
-		c.SendError("failed to add notification")
-		return
-	}
 	payload := map[string]any{
 		"type": "notification",
 		"case": "group_event",

--- a/backend/pkg/websocket/eventNotification.go
+++ b/backend/pkg/websocket/eventNotification.go
@@ -3,6 +3,7 @@ package websocket
 import (
 	"encoding/json"
 	"fmt"
+
 	"social/pkg/model"
 	"social/pkg/repository"
 	"social/pkg/util"
@@ -78,4 +79,8 @@ func (c *Client) SendEventNotification(msg map[string]any, q *repository.Query, 
 		eventID,
 		"group-event",
 	})
+	if err != nil {
+		c.SendError("failed to add notification")
+		return
+	}
 }

--- a/backend/pkg/websocket/eventNotification.go
+++ b/backend/pkg/websocket/eventNotification.go
@@ -64,6 +64,12 @@ func (c *Client) SendEventNotification(msg map[string]any, q *repository.Query, 
 		return
 	}
 
+	for _, id := range memberIds {
+		if id == c.UserID {
+			continue
+		}
+	}
+
 	// add notification
 	eventStr := fmt.Sprintf(" created event - %s", event.Title)
 	err = q.InsertData("notifications", []string{

--- a/backend/pkg/websocket/messages.go
+++ b/backend/pkg/websocket/messages.go
@@ -49,6 +49,8 @@ func (c *Client) ProcessMessages(q *repository.Query, h *Hub) {
 			c.DeleteNotification(msg, q)
 		case "member_group_invitation_proposal":
 			c.SendMemberInvitationProposal(msg, q, h)
+		case "group_event":
+			c.SendEventNotification(msg, q, h)
 		default:
 			c.SendError("Unknown message type")
 		}


### PR DESCRIPTION
### Summary

This PR introduces support for **group-based event notifications** via WebSockets. It ensures that both individual users and group members can receive relevant real-time event alerts.

---

### Changes Introduced

#### Database Migration

* Added a **new migration** to introduce the `group_recipient_id` field to the `notifications` table.
* This field is `NOT NULL`, so for existing Naeka users (who are not in groups), it is set to an empty string (`""`).

#### Notification Storage

* Events are now saved to the `notifications` table:

  * In the **WebSocket logic** for persistence

####  Notification Fetch Logic

* The notification fetch query has been updated to:

  * Return notifications where:

    * The `recipient_id` matches the user
    * OR the user belongs to a group, and the `group_recipient_id` matches that group
  * Also filters to return **only unread** notifications
* Reminder: notifications are cached in `localStorage`, so if all show up together it’s expected behavior.

#### Code Structure Improvements

* Moved `AddEvent` struct to the **WebSocket models package** to eliminate circular dependencies.

#### New WebSocket Function

* Added a backend WebSocket function: `eventNotification`, which handles sending group or user-targeted event notifications.

---
